### PR TITLE
Attachments path fixes.

### DIFF
--- a/FileSystem/FileSystem.php
+++ b/FileSystem/FileSystem.php
@@ -117,19 +117,20 @@ class FileSystem
     {
         $router = $this->container->get('router');
         $request = $this->requestStack->getCurrentRequest();
-
+        $script_name = $request->server->get('SCRIPT_NAME');
+        
         if ($request->isSecure()) {
             $baseURL = "https:////" . $request->getHttpHost() . '/';
         } else {
             $baseURL = "http:////" . $request->getHttpHost() . '/';
         }
-
+        
         $assetDetails = [
             'id' => $attachment->getId(),
             'name' => $attachment->getName(),
-            'path' => $baseURL . $attachment->getPath(),
+            'path' => $baseURL . "$script_name/" . $attachment->getPath(),
             'relativePath' => $attachment->getPath(),
-            'iconURL' => $baseURL . $this->getAssetIconURL($attachment),
+            'iconURL' => $baseURL .  dirname($script_name) . '/'  . $this->getAssetIconURL($attachment),
             'downloadURL' => null,
         ];
 

--- a/FileSystem/FileSystem.php
+++ b/FileSystem/FileSystem.php
@@ -117,13 +117,15 @@ class FileSystem
     {
         $router = $this->container->get('router');
         $request = $this->requestStack->getCurrentRequest();
-        $script_name = $request->server->get('SCRIPT_NAME');
-        
+
         if ($request->isSecure()) {
-            $baseURL = "https:////" . $request->getHttpHost() . '/';
-        } else {
-            $baseURL = "http:////" . $request->getHttpHost() . '/';
+            $router->getContext->setSecure('https');
         }
+        $baseURL = $router->generate('base_route', [], UrlGeneratorInterface::ABSOLUTE_URL);
+    
+        if ('/' == substr($baseURL, -1)) {
+            $baseURL = substr($baseURL, 0, -1);
+        } 
         
         $assetDetails = [
             'id' => $attachment->getId(),
@@ -143,9 +145,6 @@ class FileSystem
                 'attachmendId' => $attachment->getId(),
             ]);
         }
-
-        $assetDetails['path'] = str_replace('//', '/', $assetDetails['path']);
-        $assetDetails['iconURL'] = str_replace('//', '/', $assetDetails['iconURL']);
 
         return $assetDetails;
     }

--- a/FileSystem/FileSystem.php
+++ b/FileSystem/FileSystem.php
@@ -119,7 +119,7 @@ class FileSystem
         $request = $this->requestStack->getCurrentRequest();
 
         if ($request->isSecure()) {
-            $router->getContext->setSecure('https');
+            $router->getContext()->setScheme('https');
         }
         $baseURL = $router->generate('base_route', [], UrlGeneratorInterface::ABSOLUTE_URL);
     


### PR DESCRIPTION
**Issue** #237
**invalid base url for file icon** 
- Append server's script name fetched from request's server parameter bag  to the attachment base path
- Remove index.php from the script name in the case of asset icon path