### PR TITLE
CC/BCC User/Collaborator reply via email not update into ticket 

### DIFF
--- a/Controller/Thread.php
+++ b/Controller/Thread.php
@@ -96,6 +96,7 @@ class Thread extends Controller
                 $this->get('event_dispatcher')->dispatch('uvdesk.automation.workflow.execute', $event);
                 break;
             case 'reply':
+            case 'forward':
                 $event = new GenericEvent(CoreWorkflowEvents\Ticket\AgentReply::getId(), [
                     'entity' =>  $ticket,
                     'thread' =>  $thread

--- a/Services/TicketService.php
+++ b/Services/TicketService.php
@@ -1303,8 +1303,8 @@ class TicketService
         $timeFormat = $website->getTimeformat();
 
         $activeUser = $this->container->get('user.service')->getSessionUser();
-        $agentTimeZone = $activeUser->getTimezone();
-        $agentTimeFormat = $activeUser->getTimeformat();
+        $agentTimeZone = !empty($activeUser) ? $activeUser->getTimezone() : null;
+        $agentTimeFormat = !empty($activeUser) ? $activeUser->getTimeformat() : null;
 
         $parameterType = gettype($dateFlag);
         if($parameterType == 'string'){


### PR DESCRIPTION
**Issue** #195
**cc user/collaborator reply via email not update into ticket**
- Make sure that active user is not null before calling methods on it in Ticket Service around line 1306.
- Execute the same workflow for thread type **_forward_** as for thread type _**reply**_ 