### PR TITLE
[ISSUE RESOLVED] Custom locales replaced by default locales when upda…

### DIFF
--- a/Controller/EmailSettingsXHR.php
+++ b/Controller/EmailSettingsXHR.php
@@ -12,6 +12,18 @@ class EmailSettingsXHR extends Controller
     public function updateSettingsXHR(Request $request)
     {
         $filePath = $this->get('kernel')->getProjectDir() . '/config/packages/uvdesk.yaml';
+        
+        $app_locales = 'en|fr|it'; //default app_locales values
+        foreach( file($filePath) as $val)
+        {
+            $exploded = explode(":", trim($val));
+            if($exploded[0] == 'app_locales' && ($app_locales != $exploded[1]))
+            {
+                $app_locales = trim($exploded[1]);
+            }
+        }
+        
+        
         $supportEmailConfiguration = json_decode($request->getContent(), true);
         
         $mailer_id = ( $supportEmailConfiguration['mailer_id'] == 'None Selected' ? '~' : $supportEmailConfiguration['mailer_id'] );
@@ -21,6 +33,7 @@ class EmailSettingsXHR extends Controller
             '{{ SUPPORT_EMAIL_NAME }}' => $supportEmailConfiguration['name'],
             '{{ SUPPORT_EMAIL_MAILER_ID }}' => $mailer_id,
             '{{ SITE_URL }}' => $this->container->getParameter('uvdesk.site_url'),
+            '{{ APP_LOCALES }}' => $app_locales,
         ]);
         
         // update uvdesk.yaml file

--- a/Templates/uvdesk.php
+++ b/Templates/uvdesk.php
@@ -3,7 +3,7 @@
 return <<<STRING
 
 parameters:
-    app_locales: en|fr|it
+    app_locales: {{ APP_LOCALES }}
     
     # Default Assets
     assets_default_agent_profile_image_path: 'bundles/uvdeskcoreframework/images/uv-avatar-batman.png'


### PR DESCRIPTION
### 1. Why is this change necessary?
This change prevents the custom app_locale yaml settings inside uvdesk.yaml from getting overwritten to the default app_locale settings. 

### 2. What does this change do, exactly?
When Email settings are being updated, the app_locales in uvdesk.yaml gets reverted back to the default values of en|fr|it , any custom locales that were saved gets overwritten. 

### 3. Issue Link:
https://github.com/uvdesk/community-skeleton/issues/252

