### PR TITLE
Fix email validation

### DIFF
--- a/Resources/views/SwiftMailer/manageConfigurations.html.twig
+++ b/Resources/views/SwiftMailer/manageConfigurations.html.twig
@@ -248,7 +248,7 @@
                             msg: '{{ "Please specify a valid email address"|trans }}'
                         },
                         {
-                            pattern: /^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/,
+                            pattern: /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
                             msg: '{{ "Please specify a valid email address"|trans }}'
                         }
                     ],


### PR DESCRIPTION
### 1. Why is this change necessary?
Email validation uses a regex that doesn't accept the latest TLDs, such as .support. The TLD limit is 4 characters

### 2. What does this change do, exactly?
The code modification replaces the regex with a more complete and recent one, to try to use a standard, I used the one used by the HTML standard for validating inputs in HTML5 https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type%3Demail)

### 3. Please link to the relevant issues (if any).
#334