### PR TITLE
broken image code fix

### DIFF
--- a/Resources/views/ticketList.html.twig
+++ b/Resources/views/ticketList.html.twig
@@ -2013,7 +2013,7 @@
                                     parent.find('.uv-no-results').hide();
                                     _.each(response, function(item) {
                                         if(currentElement.attr('data-filter-type') == 'customer') {
-                                            var img = item.smallThumbnail ? item.smallThumbnail : "{{ asset(default_customer_image_path) }}";
+                                            var img = item.smallThumbnail ? "{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset('') }}"+item.smallThumbnail : "{{ asset(default_customer_image_path)}}";
                                             parent.find('.uv-dropdown-list ul').append("<li data-id='" + item.id + "'><img src='" + img + "'/>" + item.name + "</li>")
                                         } else
                                             parent.find('.uv-dropdown-list ul').append("<li data-id='" + item.id + "'>" + item.name + "</li>")


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Whenever an agent or admin tries to search the ticket from TicketList on the basis of a filter the result will take the broken image with their name.

### 2. What does this change do, exactly?
After these changes, Admin & agent get the profile image with their name in the search option.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/327