### PR TITLE
Adding information about emails copied on the initial ticket thread

### DIFF
--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -754,6 +754,11 @@
                                     <span class="timeago uv-margin-0" data-timestamp="{{ ticket.createdAt.getTimestamp() }}" title="{{ ticket.createdAt.format('d-m-Y h:ia') }}">{{ ticket_service.timeZoneConverter(ticket.createdAt) }}</span>
                                     - {{ initialThread.user.name }} <span class="uv-ticket-strip-label">{{ 'created Ticket'|trans }}</span>
                                 </span>
+								{% if initialThread.cc != '' %}
+									<div class="uv-ticket-strip">
+										<span><span class="uv-ticket-strip-label">{{ 'CC'|trans }} -</span> {{ initialThread.cc }}</span>
+									</div>
+								{% endif %}                                
                             </div>
 
                             <div class="uv-ticket-main-lt">

--- a/Services/TicketService.php
+++ b/Services/TicketService.php
@@ -1093,6 +1093,7 @@ class TicketService
                 'timestamp' => $initialThread->getCreatedAt()->getTimestamp(),
                 'createdAt' => $initialThread->getCreatedAt()->format('d-m-Y h:ia'),
                 'user' => $authorInstance->getPartialDetails(),
+                'cc' => is_array($initialThread->getCc()) ? implode(', ', $initialThread->getCc()) : '',
             ];
 
             $attachments = $threadDetails['attachments']->getValues();


### PR DESCRIPTION
When initial ticket is created and there are emails copied - users are receiving emails that ticket was created, but no information was displayed about copied emails on the interface.

### 1. Why is this change necessary?
To know who was copied on the initial ticket - if we want include the people on reply for example

### 2. What does this change do, exactly?
Displays information about the copied emails
