### PR TITLE
member&customer prefix updates

### DIFF
--- a/Controller/EmailSettingsXHR.php
+++ b/Controller/EmailSettingsXHR.php
@@ -30,8 +30,8 @@ class EmailSettingsXHR extends AbstractController
     {
         $filePath = $this->kernel->getProjectDir() . '/config/packages/uvdesk.yaml';
 
-        $memberPrefix = $this->getParameter('uvdesk_site_path.member_prefix') ?? 'member';
-        $customerPrefix = $this->getParameter('uvdesk_site_path.knowledgebase_customer_prefix') ?? 'customer';
+        $memberPrefix = "$this->getParameter('uvdesk_site_path.member_prefix')" ?? 'member';
+        $customerPrefix = "$this->getParameter('uvdesk_site_path.knowledgebase_customer_prefix')" ?? 'customer';
 
         $app_locales = 'en|fr|it'; //default app_locales values
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk ! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
  As we updated in email setting , it will updated the "UVdesk.yaml"  & set Customer & member prefix default value

### 2. What does this change do, exactly?
It will take the value as string and check if it is null then only default values set .

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/399