### PR TITLE
Broken image in reports search filter

### DIFF
--- a/Resources/views/Reports/listAgentActivities.html.twig
+++ b/Resources/views/Reports/listAgentActivities.html.twig
@@ -100,9 +100,9 @@
                                     {% set options = options|merge([{'id': agent.id, 'name': agent.name}]) %}
                                     <li data-id="{{agent.id}}" class="agentId">
                                         {% if agent.smallThumbnail != null %}
-                                            <img src="{{ agent.smallThumbnail }}"/>
+                                            <img src="{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset('') }}{{ agent.smallThumbnail }}"/>
                                         {% else %}
-                                            {# <img src="{{ agentAsset }}"/> #}
+                                            {# <img src="{{ asset(default_agent_image_path) }}"/> #}
                                         {% endif %}
                                         {{agent.name}}
                                     </li>


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
when filter agent in search option in report agent-profile image broked .

### 2. What does this change do, exactly?
the image wil get the proper url and it will not broked again.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/365