### PR TITLE
adding private global variable  in ticket Rating system repository

### DIFF
--- a/Repository/TicketRatingRepository.php
+++ b/Repository/TicketRatingRepository.php
@@ -22,6 +22,7 @@ class TicketRatingRepository extends \Doctrine\ORM\EntityRepository
 {
     public $safeFields = array('page','limit','sort','order','direction');
     const LIMIT = 10;
+    private $container;
 
     public function getRatedTicketList(\Symfony\Component\HttpFoundation\ParameterBag $obj = null, $container) {
     	$data = array_reverse($obj->all());


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
These changes make the $conatiner variable global.

### 2. What does this change do, exactly?
it helps to access the $conatiner variable globally.

### 3. Please link to the relevant issues (if any).
