### PR TITLE
changes for save password encryption in swiftmailer.yaml

### DIFF
--- a/Controller/SwiftMailer.php
+++ b/Controller/SwiftMailer.php
@@ -38,6 +38,7 @@ class SwiftMailer extends Controller
     {
         if ($request->getMethod() == 'POST') {
             $params = $request->request->all();
+            $params['password'] = base64_encode($params['password']);
             $swiftmailer = $this->swiftMailer;
 
             $swiftmailerConfiguration = $swiftmailer->createConfiguration($params['transport'], $params['id']);
@@ -78,7 +79,8 @@ class SwiftMailer extends Controller
         }
 
         if ($request->getMethod() == 'POST') {
-            $params = $request->request->all();   
+            $params = $request->request->all(); 
+            $params['password'] = base64_encode($params['password']);  
             $existingSwiftmailerConfiguration = clone $swiftmailerConfiguration;
             $swiftmailerConfiguration = $swiftmailerService->createConfiguration($params['transport'], $params['id']);
             $swiftmailerConfiguration->initializeParams($params);

--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -492,6 +492,7 @@ class EmailService
         // Retrieve mailer to be used for sending emails
         try {
             $mailer = $this->container->get('swiftmailer.mailer' . (('default' == $mailerID) ? '' : ".$mailerID"));
+            $mailer->getTransport()->setPassword(base64_decode($mailer->getTransport()->getPassword()));
         } catch (\Exception $e) {
             // @TODO: Log exception - Mailer not found
             return;


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Swiftmailer & mailbox passwords are saved without encryption & it will not good for security.

### 2. What does this change do, exactly?
This will save your swift mailer password in encryption form. 
Encryption is important because it allows you to securely protect data that you don't want anyone else to have access to
Also, it will resolve the issue of special characters taken in password

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/429
https://github.com/uvdesk/community-skeleton/issues/276
