### PR TITLE
changes for timestamp for user side

### DIFF
--- a/Services/UserService.php
+++ b/Services/UserService.php
@@ -786,7 +786,12 @@ class UserService
     public function getLocalizedFormattedTime($user = null, \DateTime $timestamp, $format = 'm-d-y h:i A')
     {
         $activeUserTimeZone = $this->entityManager->getRepository('UVDeskCoreFrameworkBundle:Website')->findOneBy(['code' => 'Knowledgebase']);
-        if (!empty($user) && $user != 'anon.' && $activeUserTimeZone->getTimezone() != null) {
+        if (!empty($user) && $user != 'anon.' && $user->getTimezone() != null) {
+            $timestamp = clone $timestamp;
+            
+            $timestamp->setTimeZone(new \DateTimeZone($user->getTimeZone()));
+            $format = $user->getTimeFormat();
+        }else{
             $timestamp = clone $timestamp;
             
             $timestamp->setTimeZone(new \DateTimeZone($activeUserTimeZone->getTimeZone()));


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a customer wants to set their timestamp with their need. They can't set now.

### 2. What does this change do, exactly?
It will help customers to set their timestamp as per their needs.

### 3. Please link to the relevant issues (if any).
