### PR TITLE
chnages for zip attachment downloads

### DIFF
--- a/Controller/Ticket.php
+++ b/Controller/Ticket.php
@@ -435,6 +435,9 @@ class Ticket extends Controller
     {
         $threadId = $request->attributes->get('threadId');
         $attachmentRepository = $this->getDoctrine()->getManager()->getRepository('UVDeskCoreFrameworkBundle:Attachment');
+        $threadRepository = $this->getDoctrine()->getManager()->getRepository('UVDeskCoreFrameworkBundle:Thread');
+
+        $thread = $threadRepository->findOneById($threadId);
 
         $attachment = $attachmentRepository->findByThread($threadId);
 
@@ -442,7 +445,7 @@ class Ticket extends Controller
             $this->noResultFound();
         }
 
-        $ticket = $attachment->getThread()->getTicket();
+        $ticket = $thread->getTicket();
         $user = $this->userService->getSessionUser();
         
         // Proceed only if user has access to the resource


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

1. Why is this change necessary?
For now, if the admin or agent want to download attachments it gives a getThread() error

2. What does this change do, exactly?
After the change in ticket.php, it will be easy to download the single attachment or zip attachment

3. Please link to the relevant issues (if any).
