### PR TITLE
forward message format issue & ticket.lastCollaboratorName & Email fix 

### DIFF
--- a/Controller/Thread.php
+++ b/Controller/Thread.php
@@ -159,9 +159,10 @@ class Thread extends Controller
                 return str_replace('//', '/', $projectDir . "/public" . $attachment->getPath());
                 }, $attachments);
 
+                $message = '<html><body style="background-image: none"><p>'.html_entity_decode($thread->getMessage()).'</p></body></html>';
                 // Forward thread to users
                 try {
-                    $messageId = $this->emailService->sendMail($params['subject'] ?? ("Forward: " . $ticket->getSubject()), $thread->getMessage(), $thread->getReplyTo(), $headers, $ticket->getMailboxEmail(), $attachments ?? [], $thread->getCc() ?: [], $thread->getBcc() ?: []);
+                    $messageId = $this->emailService->sendMail($params['subject'] ?? ("Forward: " . $ticket->getSubject()), $message, $thread->getReplyTo(), $headers, $ticket->getMailboxEmail(), $attachments ?? [], $thread->getCc() ?: [], $thread->getBcc() ?: []);
     
                     if (!empty($messageId)) {
                         $thread->setMessageId($messageId);

--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -424,8 +424,8 @@ class EmailService
             'ticket.agentName' => !empty($agentPartialDetails) ? $agentPartialDetails['name'] : '',
             'ticket.agentEmail' => !empty($agentPartialDetails) ? $agentPartialDetails['email'] : '',
             'ticket.attachments' => '',
-            'ticket.collaboratorName' => '',
-            'ticket.collaboratorEmail' => '',
+            'ticket.collaboratorName' => $this->getCollaboratorName($ticket),
+            'ticket.collaboratorEmail' => $this->getCollaboratorEmail($ticket),
             'ticket.agentLink' => sprintf("<a href='%s'>#%s</a>", $viewTicketURLAgent, $ticket->getId()),
             'ticket.ticketGenerateUrlAgent' => sprintf("<a href='%s'>click here</a>", $generateTicketURLAgent),
             'ticket.customerLink' => sprintf("<a href='%s'>#%s</a>", $viewTicketURL, $ticket->getId()),
@@ -546,5 +546,36 @@ class EmailService
         }
 
         return null;
+    }
+
+    public function getCollaboratorName($ticket)
+    {
+        if(count($ticket->getCollaborators()) > 0) {
+            try {
+                $ticket->lastCollaborator = $ticket->getCollaborators()[ -1 + count($ticket->getCollaborators()) ];
+            } catch(\Exception $e) {
+            }
+        }
+        if($ticket->lastCollaborator) {
+            $name =  $ticket->lastCollaborator->getFirstName()." ".$ticket->lastCollaborator->getLastName();
+        }
+        
+        return $name;
+        
+    }
+
+    public function getCollaboratorEmail($ticket)
+    {
+        if(count($ticket->getCollaborators()) > 0) {
+            try {
+                $ticket->lastCollaborator = $ticket->getCollaborators()[ -1 + count($ticket->getCollaborators()) ];
+            } catch(\Exception $e) {
+            }
+        }
+        if($ticket->lastCollaborator) {
+            $email = $ticket->lastCollaborator->getEmail();
+        }
+        
+        return $email;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
As we forward a thread it will send a mail to that agent or person for now it will send HTML tags in emails && In email templates if we choose a ticket.lastCollaboratorName & Email always returns null.

### 2. What does this change do, exactly?
For now it will not send Html tags in email & Also fixed for ticket.lastCollaboratorName & Email 

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/428