### PR TITLE
Added note for manual create workflow & it will send the note in email reply

### DIFF
--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -411,7 +411,7 @@ class EmailService
         $placeholderParams = [
             'ticket.id' => $ticket->getId(),
             'ticket.subject' => $ticket->getSubject(),
-            'ticket.message' =>  (isset($ticket->createdThread)) ? $ticket->createdThread->getMessage() : '',
+            'ticket.message' =>  (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : $ticket->currentThread->getMessage(),
             'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : $ticket->currentThread->getMessage(),
             'ticket.tags' => implode(',', $supportTags),
             'ticket.source' => ucfirst($ticket->getSource()),

--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -412,7 +412,7 @@ class EmailService
             'ticket.id' => $ticket->getId(),
             'ticket.subject' => $ticket->getSubject(),
             'ticket.message' =>  (isset($ticket->createdThread)) ? $ticket->createdThread->getMessage() : '',
-            'ticket.threadMessage' => (isset($ticket->createdThread)) ? $ticket->createdThread->getMessage() : '',
+            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : $ticket->currentThread->getMessage(),
             'ticket.tags' => implode(',', $supportTags),
             'ticket.source' => ucfirst($ticket->getSource()),
             'ticket.status' => $ticket->getStatus()->getDescription(),


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If we create a workflow with a note added to it then it will add that note in place of the message 

### 2. What does this change do, exactly?
After the update the code If that is a note or not it will not be added a note in place of the message

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/433
