### PR TITLE
Updates for new search bar feature on saved replies & also fixes of some issues

### DIFF
--- a/Resources/views/dashboard.html.twig
+++ b/Resources/views/dashboard.html.twig
@@ -214,7 +214,7 @@
         {{ uvdesk_extensibles.getRegisteredComponent('Webkul\\UVDesk\\CoreFrameworkBundle\\Dashboard\\Dashboard').getHomepageTemplate().render()|raw }}
 
         <div class="uv-copyright">
-            <span class="uv-credit-text">{{ 'Powered by'|trans }} <a href="https://www.uvdesk.com" target="_blank">UVdesk</a></span> | <span class="uv-credit-text">V -1.0.13</span>
+            <span class="uv-credit-text">{{ 'Powered by'|trans }} <a href="https://www.uvdesk.com" target="_blank">UVdesk</a></span> | <span class="uv-credit-text">V -1.0.16</span>
         </div>
     </div>
 {% endblock %}

--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -1203,6 +1203,24 @@
         <div class="uv-no-threads">{{ 'Nothing interesting here...'|trans }}</div>
     </script>
 
+    <script> 
+        $(document).ready(function() {
+            $("#filterSavedreplies").on("keyup", function() {
+                if (this.value.length && this.value.length != '') {
+                    var that = this;
+                    $("#listSavedReplies li").hide().filter(function() {
+                        return $(this).html().toLowerCase().indexOf(that.value.toLowerCase()) !== -1;
+                    }).show();
+                } else {
+                    $("#listSavedReplies li").show()
+                }
+            });
+                $(".uv-dropdown-btn").click(function() {
+                    $(".uv-search-inline").focus();
+                });
+        });
+    </script>
+
     <script id="thread_list_item_tmp" type="text/template">
         <div class="uv-ticket-strip">
             <span>

--- a/Resources/views/tickets/quick-actions/saved-replies.html.twig
+++ b/Resources/views/tickets/quick-actions/saved-replies.html.twig
@@ -1,15 +1,15 @@
 <div class="uv-dropdown saved-reply">
     <div class="uv-dropdown-btn">{{ 'Saved Replies'|trans }}</div>
-    <div class="uv-dropdown-list uv-top-left">
+    <div class="uv-dropdown-list uv-top-left" style="width:360px !important;">
         <div class="uv-dropdown-container">
             <label>{{ 'Saved Replies'|trans }}</label>
-            <ul>
+            <ul id="listSavedReplies">
+                <input id="filterSavedreplies" type="text" class="uv-search-inline" autofocus="autofocus"  style="width:98%">
                 <li data-id="">
-                    <a href="{{ path('helpdesk_member_saved_replies') }}" target="_blank" style="color: #2750C4">{{ 'Create New'|trans }}</a>
+                    <a href="{{ path('helpdesk_member_saved_replies') }}" target="_blank" style="color: #2750C4">{{ 'create new'|trans }}</a>
                 </li>
-                
                 {% for savedReply in ticket_service.getSavedReplies() %}
-                    <li data-id="{{ savedReply.id }}">
+                    <li class="savedReplyData" data-id="{{ savedReply.id }}">
                         {{ savedReply.name }}
                     </li>
                 {% endfor %}

--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -412,7 +412,7 @@ class EmailService
             'ticket.id' => $ticket->getId(),
             'ticket.subject' => $ticket->getSubject(),
             'ticket.message' =>  (isset($ticket->createdThread)) ? $ticket->createdThread->getMessage() : '',
-            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : (isset($ticket->currentThread)) ? $ticket->currentThread->getMessage() : '',
+            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : ((isset($ticket->currentThread)) ? $ticket->currentThread->getMessage() : ''),
             'ticket.tags' => implode(',', $supportTags),
             'ticket.source' => ucfirst($ticket->getSource()),
             'ticket.status' => $ticket->getStatus()->getDescription(),
@@ -550,32 +550,36 @@ class EmailService
 
     public function getCollaboratorName($ticket)
     {
-        if(count($ticket->getCollaborators()) > 0) {
+        $ticket->lastCollaborator = null;
+        $name = null;
+        if($ticket->getCollaborators() != null && count($ticket->getCollaborators()) > 0) {
             try {
                 $ticket->lastCollaborator = $ticket->getCollaborators()[ -1 + count($ticket->getCollaborators()) ];
             } catch(\Exception $e) {
             }
         }
-        if($ticket->lastCollaborator) {
+        if($ticket->lastCollaborator != null) {
             $name =  $ticket->lastCollaborator->getFirstName()." ".$ticket->lastCollaborator->getLastName();
         }
         
-        return $name;
+        return $name != null ? $name : '';
         
     }
 
     public function getCollaboratorEmail($ticket)
     {
-        if(count($ticket->getCollaborators()) > 0) {
+        $ticket->lastCollaborator = null;
+        $email = null;
+        if($ticket->getCollaborators() != null && count($ticket->getCollaborators()) > 0) {
             try {
                 $ticket->lastCollaborator = $ticket->getCollaborators()[ -1 + count($ticket->getCollaborators()) ];
             } catch(\Exception $e) {
             }
         }
-        if($ticket->lastCollaborator) {
+        if($ticket->lastCollaborator != null) {
             $email = $ticket->lastCollaborator->getEmail();
         }
         
-        return $email;
+        return $email != null ? $email : '';;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a user has a long list of saved replies then he/she have to find & select it manually, so that's the reason that is so hattic some time

### 2. What does this change do, exactly?
This will resolve the issue to find email saved replies by search box & also updated code for some fixes like version updated

### 3. Please link to the relevant issues (if any).
