### PR TITLE
Adding messageId when admin,agent & customer reply create & add thread/ticket

### DIFF
--- a/Workflow/Actions/Ticket/MailAgent.php
+++ b/Workflow/Actions/Ticket/MailAgent.php
@@ -63,7 +63,7 @@ class MailAgent extends WorkflowAction
         if ($entity instanceof Ticket) {
             $emailTemplate = $entityManager->getRepository('UVDeskCoreFrameworkBundle:EmailTemplates')->findOneById($value['value']);
             $emails = self::getAgentMails($value['for'], (($ticketAgent = $entity->getAgent()) ? $ticketAgent->getEmail() : ''), $container);
-            
+            $messageId = null;
             if ($emails || $emailTemplate) {
                 $queryBuilder = $entityManager->createQueryBuilder()
                     ->select('th.messageId as messageId')
@@ -104,6 +104,13 @@ class MailAgent extends WorkflowAction
                 
                 if(!empty($thread) && ($thread->getCc() || $thread->getBcc())) {
                     self::sendCcBccMail($container, $entity, $thread, $subject, $attachments, $message);
+                } else {
+                    if (!empty($messageId) & $messageId != null) {
+                        $createdThread = isset($entity->createdThread) ? $entity->createdThread : '';
+                           $createdThread->setMessageId($messageId);		 
+                           $entityManager->persist($createdThread);
+                           $entityManager->flush();
+                   }
                 }
             } else {
                 // Email Template/Emails Not Found. Disable Workflow/Prepared Response

--- a/Workflow/Actions/Ticket/MailCustomer.php
+++ b/Workflow/Actions/Ticket/MailCustomer.php
@@ -47,7 +47,7 @@ class MailCustomer extends WorkflowAction
             case $entity instanceof CoreEntities\Ticket:
                 $currentThread = isset($entity->currentThread) ? $entity->currentThread : '';
                 $createdThread = isset($entity->createdThread) ? $entity->createdThread : '';
-                
+                $messageId = null;
                 $emailTemplate = $entityManager->getRepository('UVDeskCoreFrameworkBundle:EmailTemplates')->findOneById($value);
 
                 if (empty($emailTemplate)) {
@@ -85,6 +85,13 @@ class MailCustomer extends WorkflowAction
 
                     if($thread->getCc() || $thread->getBcc()) {
                         self::sendCcBccMail($container, $entity, $thread, $subject, $attachments, $message);
+                    } else {
+                            if (!empty($messageId) & $messageId != null) {
+                                $createdThread = isset($entity->createdThread) ? $entity->createdThread : '';
+                                   $createdThread->setMessageId($messageId);		 
+                                   $entityManager->persist($createdThread);
+                                   $entityManager->flush();
+                           }
                     }
                     
                 } else {


### PR DESCRIPTION
…ad from the dashboard

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
For now, no added message Id if admin agent & customer create a ticket

### 2. What does this change do, exactly?
This will add more reference id during the creation of ticket when agent, admin & customer reply or create a ticket

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/397
