### PR TITLE
changes for ticket.message & ticket.threadMessage value 

### DIFF
--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -411,8 +411,8 @@ class EmailService
         $placeholderParams = [
             'ticket.id' => $ticket->getId(),
             'ticket.subject' => $ticket->getSubject(),
-            'ticket.message' =>  (isset($ticket->createdThread)) ? $ticket->createdThread->getMessage() : '',
-            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : ((isset($ticket->currentThread)) ? $ticket->currentThread->getMessage() : ''),
+            'ticket.message' =>  (isset($ticket->createdThread)) ? $ticket->createdThread->getMessage() : $ticket->getThreads()->get(0)->getMessage(),
+            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : ((isset($ticket->currentThread)) ? $ticket->currentThread->getMessage() : $ticket->getThreads()->get(0)->getMessage()),
             'ticket.tags' => implode(',', $supportTags),
             'ticket.source' => ucfirst($ticket->getSource()),
             'ticket.status' => $ticket->getStatus()->getDescription(),


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
This will not provide any value to 'ticket.threadMessage' & 'ticket.message'.

### 2. What does this change do, exactly?
Now, After updating the code it will provide the first thread message if No value is there.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/443