### PR TITLE
added reference id's on collaborator mail send

### DIFF
--- a/Workflow/Actions/Ticket/MailLastCollaborator.php
+++ b/Workflow/Actions/Ticket/MailLastCollaborator.php
@@ -59,7 +59,7 @@ class MailLastCollaborator extends WorkflowAction
                     $subject = $container->get('email.service')->processEmailSubject($emailTemplate->getSubject(),$placeHolderValues);
                     $message = $container->get('email.service')->processEmailContent($emailTemplate->getMessage(),$placeHolderValues);
                     $email   = $entity->lastCollaborator->getEmail();
-                    $messageId = $container->get('email.service')->sendMail($subject, $message, $email);
+                    $messageId = $container->get('email.service')->sendMail($subject, $message, $email, $mailData);
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Now, when added collaborator on the ticket the notification mail goes to collaborator but when the collaborator reply on same mail it is not added to that ticket

### 2. What does this change do, exactly?
Now, we added reference id's if collaborator added on a ticket then it will check that email reference id's & added on the tickets

### 3. Please link to the relevant issues (if any).
