### PR TITLE
set focus on saved replies search option in ticketView

### DIFF
--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -1268,9 +1268,12 @@
                     $("#listSavedReplies li").show()
                 }
             });
-                $(".uv-dropdown-btn").click(function() {
+
+            $(".uv-dropdown-btn").click(function(event) {
+                setTimeout(function() {
                     $(".uv-search-inline").focus();
-                });
+                }, 100);
+            });
         });
     </script>
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
AutoFocus does not enable on search option of saved-replies in ticketView

### 2. What does this change do, exactly?
After set timeout it is working fine.

### 3. Please link to the relevant issues (if any).
