### PR TITLE
chnages for custom filed show on customer side if not selected

### DIFF
--- a/Services/UserService.php
+++ b/Services/UserService.php
@@ -37,9 +37,14 @@ class UserService
         $request = $this->requestStack->getCurrentRequest();
         //get the ticket
         $ticket = $this->entityManager->getRepository('UVDeskCoreFrameworkBundle:Ticket')->findOneById($request->attributes->get('id'));
+        $getCustomerCustomFieldSnippet = $this->container->get('custom.field.service')->getCustomerCustomFieldSnippet($ticket);
 
-        return $this->twig->render('@_uvdesk_extension_uvdesk_form_component/widgets/CustomFields/customFieldSnippetCustomer.html.twig', 
-                $this->container->get('custom.field.service')->getCustomerCustomFieldSnippet($ticket));
+        if (sizeof($getCustomerCustomFieldSnippet["ticketCustomFieldCollection"]) > 0 && sizeof($getCustomerCustomFieldSnippet["customFieldCollection"]) > 0 ) {
+            return $this->twig->render('@_uvdesk_extension_uvdesk_form_component/widgets/CustomFields/customFieldSnippetCustomer.html.twig', 
+                $getCustomerCustomFieldSnippet);
+        }
+
+        return ;
     }
 
     public function isGranted($role) {


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a customer didn't select any custom field then also, sidebar shows to the customer

### 2. What does this change do, exactly?
After adding a check on customerSinnpet if it is not finding any custom filed then it is not showing sidebar

### 3. Please link to the relevant issues (if any).
