### PR TITLE
Email replies cause new ticket thread => fixed

### DIFF
--- a/Repository/ThreadRepository.php
+++ b/Repository/ThreadRepository.php
@@ -160,4 +160,17 @@ class ThreadRepository extends \Doctrine\ORM\EntityRepository
 
         return $json;
     }
+
+    public function findThreadByRefrenceId($referenceIds)
+    {
+        $query = $this->getEntityManager()
+            ->createQuery(
+                "SELECT t FROM UVDeskCoreFrameworkBundle:Ticket t
+                WHERE t.referenceIds LIKE :referenceIds
+                ORDER BY t.id DESC"
+            )->setParameter('referenceIds', '%'.$referenceIds.'%');
+
+        return $query->setMaxResults(1)->getOneOrNullResult();
+    }
+
 }

--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -411,8 +411,8 @@ class EmailService
         $placeholderParams = [
             'ticket.id' => $ticket->getId(),
             'ticket.subject' => $ticket->getSubject(),
-            'ticket.message' => count($ticket->getThreads()) > 0 ? $ticket->getThreads()->get(0)->getMessage() : '',
-            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? $ticket->createdThread->getMessage() : ((isset($ticket->currentThread)) ? $ticket->currentThread->getMessage() : $ticket->getThreads()->get(0)->getMessage()),
+            'ticket.message' => count($ticket->getThreads()) > 0 ? preg_replace("/<img[^>]+\>/i", "", $ticket->getThreads()->get(0)->getMessage()) : '',
+            'ticket.threadMessage' => (isset($ticket->createdThread) && $ticket->createdThread->getThreadType() != "note") ? preg_replace("/<img[^>]+\>/i", "", $ticket->createdThread->getMessage()) : ((isset($ticket->currentThread)) ? preg_replace("/<img[^>]+\>/i", "", $ticket->currentThread->getMessage()) : preg_replace("/<img[^>]+\>/i", "", $ticket->getThreads()->get(0)->getMessage())),
             'ticket.tags' => implode(',', $supportTags),
             'ticket.source' => ucfirst($ticket->getSource()),
             'ticket.status' => $ticket->getStatus()->getDescription(),
@@ -457,7 +457,7 @@ class EmailService
         }
 
         $content = $isSavedReply ? stripslashes($content) : htmlspecialchars_decode(preg_replace(['#&lt;script&gt;#', '#&lt;/script&gt;#'], ['&amp;lt;script&amp;gt;', '&amp;lt;/script&amp;gt;'], $content));
-
+        dump($content); die;
         return $twigTemplatingEngine->render($baseEmailTemplate, ['message' => $content]);
     }
 

--- a/Services/EmailService.php
+++ b/Services/EmailService.php
@@ -457,7 +457,6 @@ class EmailService
         }
 
         $content = $isSavedReply ? stripslashes($content) : htmlspecialchars_decode(preg_replace(['#&lt;script&gt;#', '#&lt;/script&gt;#'], ['&amp;lt;script&amp;gt;', '&amp;lt;/script&amp;gt;'], $content));
-        dump($content); die;
         return $twigTemplatingEngine->render($baseEmailTemplate, ['message' => $content]);
     }
 

--- a/Workflow/Actions/Ticket/MailAgent.php
+++ b/Workflow/Actions/Ticket/MailAgent.php
@@ -194,13 +194,6 @@ class MailAgent extends WorkflowAction
 
             $messageId = $container->get('email.service')->sendMail($subject, $message, null, [], $entity->getMailboxEmail(), $attachments ?? [], $collabrator ?? [], []); 
             if (!empty($messageId)) {
-                $createdThread = isset($entity->createdThread) ? $entity->createdThread : '';
-                   $createdThread->setMessageId($messageId);         
-                   $entityManager->persist($createdThread);
-                   $entityManager->flush();
-           }
-
-           if (!empty($messageId)) {
             $updatedReferenceIds = $entity->getReferenceIds() . ' ' . $messageId;            
             $entity->setReferenceIds($updatedReferenceIds);
 

--- a/Workflow/Actions/Ticket/MailAgent.php
+++ b/Workflow/Actions/Ticket/MailAgent.php
@@ -104,6 +104,13 @@ class MailAgent extends WorkflowAction
                 if(!empty($emails) && $emails != null){
                     foreach ($emails as $email) {
                         $messageId = $container->get('email.service')->sendMail($subject, $message, $email, $emailHeaders, null, $attachments ?? []);
+                        if (!empty($messageId)) {
+                            $updatedReferenceIds = $entity->getReferenceIds() . ' ' . $messageId;            
+                            $entity->setReferenceIds($updatedReferenceIds);
+    
+                            $entityManager->persist($entity);
+                            $entityManager->flush();
+                        }
                     }
                 }
                 
@@ -192,6 +199,14 @@ class MailAgent extends WorkflowAction
                    $entityManager->persist($createdThread);
                    $entityManager->flush();
            }
+
+           if (!empty($messageId)) {
+            $updatedReferenceIds = $entity->getReferenceIds() . ' ' . $messageId;            
+            $entity->setReferenceIds($updatedReferenceIds);
+
+            $entityManager->persist($entity);
+            $entityManager->flush();
+            }
 
            if($thread->getCc() != null && count($thread->getCc()) == count($collabrator) && $thread->getBcc() != null){
             $message = '<html><body style="background-image: none"><p>'.html_entity_decode($thread->getMessage()).'</p></body></html>';

--- a/Workflow/Actions/Ticket/MailAgent.php
+++ b/Workflow/Actions/Ticket/MailAgent.php
@@ -95,11 +95,6 @@ class MailAgent extends WorkflowAction
                 $placeHolderValues = $container->get('email.service')->getTicketPlaceholderValues($entity, 'agent');
                 $subject = $container->get('email.service')->processEmailSubject($emailTemplate->getSubject(), $placeHolderValues);
                 $message = $container->get('email.service')->processEmailContent($emailTemplate->getMessage(), $placeHolderValues);
-                $bodyImageExtract = explode('<p style="text-align: center"><img',$message);
-                if (!array_key_exists(1,$bodyImageExtract)) {
-                    $bodyImageExtract = explode('<p style="text-align: center;"><img',$message);
-                }
-                $message = $bodyImageExtract['0'].' <p style="text-align: center"><img'.preg_replace("/<img[^>]+\>/i", "", $bodyImageExtract['1']);
                 $thread = ($thread != null) ? $thread : $createdThread;
                 if ($thread != null && $thread->getThreadType() == "reply" && $thread->getCreatedBy() != "collaborator") {
                     $ticketCollaborators = (($thread != null) && !empty($thread->getTicket()) && $thread != "" ) ? $thread->getTicket()->getCollaborators() : [];

--- a/Workflow/Actions/Ticket/MailAgent.php
+++ b/Workflow/Actions/Ticket/MailAgent.php
@@ -95,7 +95,11 @@ class MailAgent extends WorkflowAction
                 $placeHolderValues = $container->get('email.service')->getTicketPlaceholderValues($entity, 'agent');
                 $subject = $container->get('email.service')->processEmailSubject($emailTemplate->getSubject(), $placeHolderValues);
                 $message = $container->get('email.service')->processEmailContent($emailTemplate->getMessage(), $placeHolderValues);
-                $message = preg_replace("/<img[^>]+\>/i", "(image) ", $message);
+                $bodyImageExtract = explode('<p style="text-align: center"><img',$message);
+                if (!array_key_exists(1,$bodyImageExtract)) {
+                    $bodyImageExtract = explode('<p style="text-align: center;"><img',$message);
+                }
+                $message = $bodyImageExtract['0'].' <p style="text-align: center"><img'.preg_replace("/<img[^>]+\>/i", "", $bodyImageExtract['1']);
                 $thread = ($thread != null) ? $thread : $createdThread;
                 if ($thread != null && $thread->getThreadType() == "reply" && $thread->getCreatedBy() != "collaborator") {
                     $ticketCollaborators = (($thread != null) && !empty($thread->getTicket()) && $thread != "" ) ? $thread->getTicket()->getCollaborators() : [];

--- a/Workflow/Actions/Ticket/MailCustomer.php
+++ b/Workflow/Actions/Ticket/MailCustomer.php
@@ -66,11 +66,6 @@ class MailCustomer extends WorkflowAction
                 $ticketPlaceholders = $container->get('email.service')->getTicketPlaceholderValues($entity);
                 $subject = $container->get('email.service')->processEmailSubject($emailTemplate->getSubject(), $ticketPlaceholders);
                 $message = $container->get('email.service')->processEmailContent($emailTemplate->getMessage(), $ticketPlaceholders);
-                $bodyImageExtract = explode('<p style="text-align: center"><img',$message);
-                if (!array_key_exists(1,$bodyImageExtract)) {
-                    $bodyImageExtract = explode('<p style="text-align: center;"><img',$message);
-                }
-                $message = $bodyImageExtract['0'].' <p style="text-align: center"><img'.preg_replace("/<img[^>]+\>/i", "", $bodyImageExtract['1']);
                 $thread = ($thread != null) ? $thread : $createdThread;
                 $ticketCollaborators = (($thread != null) && !empty($thread->getTicket()) && $thread != "" ) ? $thread->getTicket()->getCollaborators() : [];
 

--- a/Workflow/Actions/Ticket/MailCustomer.php
+++ b/Workflow/Actions/Ticket/MailCustomer.php
@@ -79,11 +79,13 @@ class MailCustomer extends WorkflowAction
 
                     $messageId = $container->get('email.service')->sendMail($subject, $message, $entity->getCustomer()->getEmail(), $headers, $entity->getMailboxEmail(), $attachments ?? []);
 
-                    // if (!empty($messageId)) {
-                    //     $createdThread->setMessageId($messageId);
-                    //     $entityManager->persist($createdThread);
-                    //     $entityManager->flush();
-                    // }
+                    if (!empty($messageId)) {
+                        $updatedReferenceIds = $entity->getReferenceIds() . ' ' . $messageId;            
+                        $entity->setReferenceIds($updatedReferenceIds);
+
+                        $entityManager->persist($entity);
+                        $entityManager->flush();
+                    }
 
                     if($thread->getCc() || $thread->getBcc() || $ticketCollaborators != null && count($ticketCollaborators) > 0) {
                         self::sendCcBccMail($container, $entity, $thread, $subject, $attachments, $message, $ticketCollaborators);
@@ -131,6 +133,14 @@ class MailCustomer extends WorkflowAction
                    $entityManager->persist($createdThread);
                    $entityManager->flush();
            }
+
+           if (!empty($messageId)) {
+            $updatedReferenceIds = $entity->getReferenceIds() . ' ' . $messageId;            
+            $entity->setReferenceIds($updatedReferenceIds);
+
+            $entityManager->persist($entity);
+            $entityManager->flush();
+            }
 
            if($collabrator != null && $thread->getCc()!= null && count($thread->getCc()) == count($collabrator) && $thread->getBcc() != null){
             $message = '<html><body style="background-image: none"><p>'.html_entity_decode($thread->getMessage()).'</p></body></html>';

--- a/Workflow/Actions/Ticket/MailCustomer.php
+++ b/Workflow/Actions/Ticket/MailCustomer.php
@@ -66,7 +66,11 @@ class MailCustomer extends WorkflowAction
                 $ticketPlaceholders = $container->get('email.service')->getTicketPlaceholderValues($entity);
                 $subject = $container->get('email.service')->processEmailSubject($emailTemplate->getSubject(), $ticketPlaceholders);
                 $message = $container->get('email.service')->processEmailContent($emailTemplate->getMessage(), $ticketPlaceholders);
-                $message = preg_replace("/<img[^>]+\>/i", "(image) ", $message);
+                $bodyImageExtract = explode('<p style="text-align: center"><img',$message);
+                if (!array_key_exists(1,$bodyImageExtract)) {
+                    $bodyImageExtract = explode('<p style="text-align: center;"><img',$message);
+                }
+                $message = $bodyImageExtract['0'].' <p style="text-align: center"><img'.preg_replace("/<img[^>]+\>/i", "", $bodyImageExtract['1']);
                 $thread = ($thread != null) ? $thread : $createdThread;
                 $ticketCollaborators = (($thread != null) && !empty($thread->getTicket()) && $thread != "" ) ? $thread->getTicket()->getCollaborators() : [];
 

--- a/Workflow/Actions/Ticket/MailCustomer.php
+++ b/Workflow/Actions/Ticket/MailCustomer.php
@@ -128,13 +128,6 @@ class MailCustomer extends WorkflowAction
 
             $messageId = $container->get('email.service')->sendMail($subject, $message, null, [], $entity->getMailboxEmail(), $attachments ?? [], $collabrator ?? [], []); 
             if (!empty($messageId)) {
-                $createdThread = isset($entity->createdThread) ? $entity->createdThread : '';
-                   $createdThread->setMessageId($messageId);         
-                   $entityManager->persist($createdThread);
-                   $entityManager->flush();
-           }
-
-           if (!empty($messageId)) {
             $updatedReferenceIds = $entity->getReferenceIds() . ' ' . $messageId;            
             $entity->setReferenceIds($updatedReferenceIds);
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If the reference Id is missing no reply is added to the ticket & create a new ticket.

### 2. What does this change do, exactly?
Added message-id to reference id if reference ids missing in the header then compare to in-reply-to.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/478