### PR TITLE
updates

### DIFF
--- a/Resources/views/savedReplyForm.html.twig
+++ b/Resources/views/savedReplyForm.html.twig
@@ -177,6 +177,10 @@
 					,{
 						pattern: '^(?!.*[!@#$%^&*()<_+])',
 						msg: "{{ 'Name must have characters only' }}"
+					},
+					{
+						maxLength:100,
+						msg: "{{ 'This field contain maximum 100 characters.'|trans }}"
 					}
 					],
 				}

--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -566,7 +566,7 @@
 
                                     <ul class="uv-search-list type" data-action="type">
                                         {% for type in ticketTypeCollection %}
-                                            <li data-index="{{ type.id }}"><a href="#">{{ type.description }}</a></li>
+                                            <li data-index="{{ type.id }}"><a href="#">{{ type.code }}</a></li>
                                         {% endfor %}
                                     </ul>
                                 </div>

--- a/Resources/views/ticketTypeAdd.html.twig
+++ b/Resources/views/ticketTypeAdd.html.twig
@@ -78,14 +78,27 @@
 		$(function () {
 			var TypeModel = Backbone.Model.extend({
 				validation: {
-					'code': {
-						required: true,
-						msg: "{{ 'This field is mandatory'|trans }}"
-					},
-					'description': {
+					'code': [{
 						required: true,
 						msg: "{{ 'This field is mandatory'|trans }}"
 					}
+					,{
+						pattern: '^(?!.*[!@#$%^&*()<_+])',
+						msg: "{{ 'Name must have characters only' }}"
+					},
+					,{
+						maxLength:200,
+						msg: "{{ 'This field contain maximum 100 characters.'|trans }}"
+					}],
+					'description': [{
+						required: true,
+						msg: "{{ 'This field is mandatory'|trans }}"
+					}
+					,{
+						maxLength:200,
+						msg: "{{ 'This field contain maximum 200 characters.'|trans }}"
+					}
+					],
 				}
 			});
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
1. When using description more than two words then showing description value in ticket view list when choosing ticket type.
2. In ticket type should take only characters not special characters
3. In ticket type code field should be shown limit warning message 
4. When using prepared responses with more than 100 words in name and description so validation is not working properly
5. In saved reply, more than 255 characters show an error instead of the warning message

### 2. What does this change do, exactly?
Fixed.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/525
https://github.com/uvdesk/core-framework/issues/526
https://github.com/uvdesk/core-framework/issues/527
https://github.com/uvdesk/core-framework/issues/528
https://github.com/uvdesk/core-framework/issues/529