### PR TITLE
List ticket types in alphabetical order and display ticket type name instead of description

### DIFF
--- a/PreparedResponse/Actions/Ticket/UpdateType.php
+++ b/PreparedResponse/Actions/Ticket/UpdateType.php
@@ -31,9 +31,10 @@ class UpdateType extends PreparedResponseAction
         return array_map(function ($ticketType) {
             return [
                 'id' => $ticketType->getId(),
-                'name' => $ticketType->getDescription(),
+                'name' => $ticketType->getCode(),
             ];
-        }, $entityManager->getRepository('UVDeskCoreFrameworkBundle:TicketType')->findAll());
+        }, $entityManager->getRepository('UVDeskCoreFrameworkBundle:TicketType')
+                           ->findBy(['isActive' => true], ['code' => 'ASC']));
     }
 
     public static function applyAction(ContainerInterface $container, $entity, $value = null)

--- a/Resources/views/Snippets/createMemberTicket.html.twig
+++ b/Resources/views/Snippets/createMemberTicket.html.twig
@@ -40,10 +40,10 @@
                 <div class="uv-field-block">
                     <select name="type" class="uv-select create-ticket" id="type">
                         <option value="">{{ 'Select type'|trans }}</option>
-
-                        {% for type in ticketTypeCollection %}
-                            <option value="{{ type.id }}">{{ type.description }}</option>
-                        {% endfor %}
+                            {% for type in ticket_service.getTypes()  %}
+                                <option value="{{ type.id }}" {{ post.type is defined and post.type == type.id ? 'selected' : '' }}>{{ type.name }}
+                                </option>
+                            {% endfor %}
                     </select>
                 </div>
                 <span class="uv-field-info">{{ 'Choose ticket type'|trans }}</span>

--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -565,7 +565,7 @@
                                     </div>
 
                                     <ul class="uv-search-list type" data-action="type">
-                                        {% for type in ticketTypeCollection %}
+                                        {% for type in ticket_service.getTypes()  %}
                                             <li data-index="{{ type.id }}"><a href="#">{{ type.name }}</a></li>
                                         {% endfor %}
                                     </ul>

--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -555,7 +555,7 @@
                         <label class="uv-aside-select-label">{{ 'Type'|trans }}</label>
                         <div>
                             {% if user_service.isAccessAuthorized('ROLE_AGENT_UPDATE_TICKET_TYPE') %}
-                                <span class="uv-aside-select-value uv-dropdown-other uv-aside-drop-icon" data-id="{{ ticket.type ? ticket.type.id : '-- --' }}">{{ ticket.type ? ticket.type.description : 'Not Assigned'|trans }}</span>
+                                <span class="uv-aside-select-value uv-dropdown-other uv-aside-drop-icon" data-id="{{ ticket.type ? ticket.type.id : '-- --' }}">{{ ticket.type ? ticket.type.code : 'Not Assigned'|trans }}</span>
                                 <div class="uv-dropdown-list uv-bottom-left">
                                     <div class="uv-dropdown-container">
                                         <label>{{ 'Type'|trans }}</label>
@@ -566,13 +566,13 @@
 
                                     <ul class="uv-search-list type" data-action="type">
                                         {% for type in ticketTypeCollection %}
-                                            <li data-index="{{ type.id }}"><a href="#">{{ type.code }}</a></li>
+                                            <li data-index="{{ type.id }}"><a href="#">{{ type.name }}</a></li>
                                         {% endfor %}
                                     </ul>
                                 </div>
                             {% else %}
                                 <span class="uv-aside-select-value">
-                                    {{ ticket.type ? ticket.type.description : 'Not Assigned'|trans }}
+                                    {{ ticket.type ? ticket.type.code : 'Not Assigned'|trans }}
                                 </span>
                             {% endif %}
                         </div>

--- a/Resources/views/ticketList.html.twig
+++ b/Resources/views/ticketList.html.twig
@@ -425,8 +425,8 @@
                                             </div>
 
                                             <ul class="uv-search-list type" data-action="type">
-                                                {% for type in ticketTypeCollection %}
-                                                    <li data-index="{{ type.id }}"><a href="#">{{ type.description }}</a></li>
+                                                {% for type in ticket_service.getTypes()  %}
+                                                    <li data-index="{{ type.id }}"><a href="#">{{ type.name }}</a></li>
                                                 {% endfor %}
                                             </ul>
                                         </div>

--- a/Workflow/Actions/Ticket/UpdateType.php
+++ b/Workflow/Actions/Ticket/UpdateType.php
@@ -31,9 +31,10 @@ class UpdateType extends WorkflowAction
         return array_map(function ($ticketType) {
             return [
                 'id' => $ticketType->getId(),
-                'name' => $ticketType->getDescription(),
+                'name' => $ticketType->getCode(),
             ];
-        }, $entityManager->getRepository('UVDeskCoreFrameworkBundle:TicketType')->findByIsActive(1));
+        }, $entityManager->getRepository('UVDeskCoreFrameworkBundle:TicketType')
+                          ->findBy(['isActive' => true], ['code' => 'ASC']));
     }
 
     public static function applyAction(ContainerInterface $container, $entity, $value = null)

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
         "psr-4": { "Webkul\\UVDesk\\CoreFrameworkBundle\\": "" }
     },
     "extra": {
-        "uvdesk-package-extension": "Webkul\\UVDesk\\CoreFrameworkBundle\\Package\\Composer"
+        "uvdesk-package-extension": "Webkul\\UVDesk\\CoreFrameworkBundle\\Package\\Composer",
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
     },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
Updated ticket types listing in alphabetical order on ticket create form on admin panel and also now showing ticket type name instead of description.

[#527 ](https://github.com/uvdesk/community-skeleton/issues/527)
https://github.com/uvdesk/support-center-bundle/issues/191
https://github.com/uvdesk/support-center-bundle/issues/190
https://github.com/uvdesk/support-center-bundle/issues/185
https://github.com/uvdesk/support-center-bundle/issues/175
