### PR TITLE
Now in the ticket option if we hit the wrong URL, ticket page shows the HTTP 400 NOT FOUND 

### DIFF
--- a/Resources/config/routes/private.yaml
+++ b/Resources/config/routes/private.yaml
@@ -182,6 +182,8 @@ helpdesk_member_ticket:
     path:     /ticket/view/{ticketId}
     controller: Webkul\UVDesk\CoreFrameworkBundle\Controller\Ticket::loadTicket
     defaults: { ticketId: 0 }
+    requirements: 
+        ticketId: \d+
 
 helpdesk_member_ticket_xhr:
     path:     /ticket/xhr/{ticketId}


### PR DESCRIPTION
Please link to the relevant issues (if any).

https://github.com/uvdesk/core-framework/issues/595
