### PR TITLE
fix: Ticket type desc. line break, error in tinymce config

### DIFF
--- a/Resources/views/ticket.html.twig
+++ b/Resources/views/ticket.html.twig
@@ -2957,7 +2957,7 @@
                         },
                         {
                             name : "{{ 'Type'|trans }}",
-                            value : "{{ ticket.type ? ticket.type.description : 'Not Assigned'|trans }}",
+                            value : "{{ ticket.type ? ticket.type.description|replace({"\n":' ', "\r":' '}) : 'Not Assigned'|trans }}",
                         },
                         {
                             name : "{{ 'Group'|trans }}",


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Fixes the issue of TinyMCE configuration error when the ticket type description has a line break.

### 2. What does this change do, exactly?
Followed already used approach of code, i.e. replaced line break (\n) and carriage return (\r) to space (' ') in the ticket type description 

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/689