### PR TITLE
Set $renameFile to true on the localhost upload manager

### DIFF
--- a/FileSystem/UploadManagers/Localhost.php
+++ b/FileSystem/UploadManagers/Localhost.php
@@ -98,7 +98,7 @@ class Localhost implements FileUploadServiceInterface
         ];
     }
 
-    public function uploadEmailAttachment(Attachment $attachmentStream, $prefix = null, bool $renameFile = false)
+    public function uploadEmailAttachment(Attachment $attachmentStream, $prefix = null, bool $renameFile = true)
     {
         $fileName = $attachmentStream->getFilename();
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

Improve security. For some reason although the app has the functionality to rename/sanitize the uploaded file names it is not being used since \$renameFile defaults to false.

### 2. What does this change do, exactly?

Sets \$renameFile to true on the upload manager.

### 3. Please link to the relevant issues (if any).

Ticket number #32140 on uvdesk.com