### PR TITLE
Add brazilian portuguese translation field option

### DIFF
--- a/Services/UVDeskService.php
+++ b/Services/UVDeskService.php
@@ -102,6 +102,7 @@ class UVDeskService
             'da' => $translator->trans("Danish"),
             'zh' => $translator->trans("Chinese"),
             'pl' => $translator->trans("Polish"),
+            'pt' => $translator->trans("Portuguese"),
         ];
     }
 

--- a/Services/UVDeskService.php
+++ b/Services/UVDeskService.php
@@ -102,7 +102,7 @@ class UVDeskService
             'da' => $translator->trans("Danish"),
             'zh' => $translator->trans("Chinese"),
             'pl' => $translator->trans("Polish"),
-            'pt' => $translator->trans("Portuguese"),
+            'pt_BR' => $translator->trans("Portuguese"),
         ];
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

I opened uvdesk/community-skeleton#793 for portuguese translation in community skeleton repository and is needed to add this option to choose language in admin interface

### 2. What does this change do, exactly?

- Change the `UVDeskService.php` adding portuguese option to getLocalteList method

### 3. Please link to the relevant issues (if any).

- Linked with uvdesk/community-skeleton#793
