### PR TITLE
Fix: Redirect 'Create New' saved reply to creation form (#717)

### DIFF
--- a/Resources/views/tickets/quick-actions/saved-replies.html.twig
+++ b/Resources/views/tickets/quick-actions/saved-replies.html.twig
@@ -6,7 +6,7 @@
             <ul id="listSavedReplies">
                 <input id="filterSavedreplies" type="text" class="uv-search-inline" autofocus="autofocus"  style="width:98%">
                 <li data-id="">
-                    <a href="{{ path('helpdesk_member_saved_replies') }}" target="_blank" style="color: #2750C4">{{ 'create new'|trans }}</a>
+                    <a href="{{ path('helpdesk_member_create_saved_replies') }}" target="_blank" style="color: #2750C4">{{ 'create new'|trans }}</a>
                 </li>
                 {% for savedReply in ticket_service.getSavedReplies() %}
                     <li class="savedReplyData" data-id="{{ savedReply.id }}">


### PR DESCRIPTION
### 1. Why is this change necessary?
The "Create New" link in Saved Replies was incorrectly pointing to the list page instead of the form.

### 2. What does this change do, exactly?
It updates the anchor tag to use the correct route: `helpdesk_member_create_saved_replies`.

### 3. Related Issue
Closes #717